### PR TITLE
Add bullet point for Pinterest tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,22 @@
       margin: 0;
       text-shadow: 0 2px 4px rgba(0,0,0,0.3);
     }
+      ul {
+        list-style: disc;
+        list-style-position: inside;
+        padding-left: 0;
+        margin-top: 1rem;
+      }
+      li {
+        font-size: 1.5rem;
+        margin: 0.5rem 0;
+      }
   </style>
 </head>
 <body>
   <h1>Doug Rangel</h1>
+  <ul>
+    <li>building AI powered internal tools at Pinterest</li>
+  </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a bullet point about building AI powered internal tools at Pinterest
- include a small style block for bullet lists

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68543a3f6180832cb2aae201e4a0010a